### PR TITLE
Update markdown_to_pdf input handling

### DIFF
--- a/mas/lib/std.json
+++ b/mas/lib/std.json
@@ -76,7 +76,7 @@
         {   "type": "process",
             "name": "markdown_to_pdf",
             "function": "fn:markdown_to_pdf",
-            "description": "Turn markdown to PDF format. Requiers 'wkhtmltopdf' and 'pdfkit' to be installed. Last message in list given to this process must contain 'markdown' and 'title' fields. Returns pdf_file_path."
+            "description": "Turn markdown to PDF format. Requires 'wkhtmltopdf' and 'pdfkit' to be installed. The latest message must include a text block with JSON containing 'markdown' and 'title'. Returns pdf_file_path."
         },
 
         {

--- a/mas/lib/std.py
+++ b/mas/lib/std.py
@@ -60,14 +60,18 @@ def weather_query(manager, location: str, unit: str = "metric") -> tuple:
     except requests.RequestException as e:
         return (None, "Unavailable", None, location)
 
-def markdown_to_pdf(messages):
+def markdown_to_pdf(manager, messages):
     import markdown
     import pdfkit
     import os
 
-    md_text = messages[-1]["message"]["markdown"]
+    # The latest message should contain a text block with a JSON string.
+    # Parse it using the manager helper to obtain a dictionary.
+    data = manager._blocks_as_tool_input(messages[-1]["message"])
 
-    title = messages[-1]["message"]["title"]
+    md_text = data["markdown"]
+
+    title = data["title"]
 
     # Convert markdown to HTML
     html_content = markdown.markdown(md_text)


### PR DESCRIPTION
## Summary
- parse `markdown_to_pdf` input from first text block using manager helper
- document updated requirements for `markdown_to_pdf` in standard library metadata

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7be6aad083329b776d3a6fcbfe45