### PR TITLE
Fix _to_blocks persistence for non-JSON values

### DIFF
--- a/mas/mas.py
+++ b/mas/mas.py
@@ -3835,7 +3835,12 @@ class AgentSystemManager:
             try:
                 dumped = json.dumps(value, ensure_ascii=False)
             except TypeError:
-                dumped = str(value)
+                # Fallback: persist non-serializable values into files
+                if isinstance(value, dict):
+                    dumped = self._dict_to_json_with_file_persistence(value, user_id)
+                else:
+                    data_copy = self._persist_non_json_values(value, user_id)
+                    dumped = json.dumps(data_copy, ensure_ascii=False)
             return [{
                 "type": "text",
                 "content": dumped

--- a/tests/test_to_blocks.py
+++ b/tests/test_to_blocks.py
@@ -1,0 +1,45 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from mas.mas import AgentSystemManager
+
+
+def create_manager(tmp_path):
+    return AgentSystemManager(
+        base_directory=str(tmp_path),
+        history_folder=str(tmp_path / "history"),
+        files_folder=str(tmp_path / "files")
+    )
+
+def roundtrip(manager, value):
+    blocks = manager._to_blocks(value, user_id="u1")
+    parsed = manager._blocks_as_tool_input(blocks)
+    return manager._load_files_in_dict(parsed)
+
+def test_dict_with_bytes(tmp_path):
+    manager = create_manager(tmp_path)
+    original = {"foo": b"bar"}
+    result = roundtrip(manager, original)
+    assert result == original
+
+    text = manager._first_text_block(manager._to_blocks(original, user_id="u1"))
+    data = json.loads(text)
+    assert isinstance(data["foo"], str) and data["foo"].startswith("file:")
+    assert os.path.exists(data["foo"][5:])
+
+def test_list_with_bytes(tmp_path):
+    manager = create_manager(tmp_path)
+    original = [b"abc", {"nested": b"def"}]
+    result = roundtrip(manager, original)
+    assert result == original
+
+    text = manager._first_text_block(manager._to_blocks(original, user_id="u1"))
+    data = json.loads(text)
+    assert data[0].startswith("file:")
+    assert os.path.exists(data[0][5:])
+    assert data[1]["nested"].startswith("file:")
+    assert os.path.exists(data[1]["nested"][5:])


### PR DESCRIPTION
## Summary
- persist dict/list values containing non-JSON-friendly objects when converting to blocks
- add regression tests for byte/object roundtrips in `_to_blocks`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7c31e6b08332b00f11319c21297f